### PR TITLE
Increase timeout to 1400s

### DIFF
--- a/tests/console/install_packages.pm
+++ b/tests/console/install_packages.pm
@@ -27,7 +27,7 @@ sub run {
     # better have it fail and let a reviewer check the reason
     assert_script_run("test -s \$XDG_RUNTIME_DIR/install_packages.txt");
     # might take longer for large patches (i.e. 12 kernel flavors)
-    assert_script_run("xargs --no-run-if-empty zypper -n in -l < \$XDG_RUNTIME_DIR/install_packages.txt", 800);
+    assert_script_run("xargs --no-run-if-empty zypper -n in -l < \$XDG_RUNTIME_DIR/install_packages.txt", 1400);
     assert_script_run("grep -Ev '^-' \$XDG_RUNTIME_DIR/install_packages.txt | xargs --no-run-if-empty rpm -q -- | tee /dev/$serialdev");
 }
 


### PR DESCRIPTION
Increased timeout to allow installation of large package sets, as needed for texlive`. Same number as `qam_zypper_patch.pm`.

Fixes: https://openqa.opensuse.org/tests/3047588#step/install_packages/11 Fixes: https://openqa.opensuse.org/tests/3047591#step/install_packages/11 Fixes: https://openqa.opensuse.org/tests/3047590#step/install_packages/11

CC: @msmeissn

[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
